### PR TITLE
Add VALUES expression

### DIFF
--- a/src/Expression/SqlExpression.php
+++ b/src/Expression/SqlExpression.php
@@ -22,11 +22,16 @@ final readonly class SqlExpression implements Expression
     }
 
     /**
-     * @param non-empty-string      $reference
-     * @param non-empty-string|null $alias
+     * @param non-empty-string|Expression $reference
+     * @param non-empty-string|null       $alias
      */
-    public static function tableReference(string $reference, ?string $alias = null): Expression
+    public static function tableReference(Expression|string $reference, ?string $alias = null): Expression
     {
+        $reference = match (true) {
+            $reference instanceof Expression => $reference->toSQL(),
+            default => $reference,
+        };
+
         return null !== $alias ? new Alias(new self($reference), $alias) : new self($reference);
     }
 
@@ -45,8 +50,13 @@ final readonly class SqlExpression implements Expression
         return new self('FALSE');
     }
 
-    public static function parenthesized(string $raw): self
+    public static function parenthesized(Expression|string $expression): self
     {
+        $raw = match (true) {
+            $expression instanceof Expression => $expression->toSQL(),
+            default => $expression,
+        };
+
         return new self('('.$raw.')');
     }
 

--- a/src/Expression/Values.php
+++ b/src/Expression/Values.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\DbalTools\Expression;
+
+final readonly class Values implements Expression
+{
+    private Expressions $rows;
+
+    public function __construct(
+        Expression $row,
+        Expression ...$rows,
+    ) {
+        $this->rows = new Expressions($row, ...$rows);
+    }
+
+    public static function row(Expression $field1, Expression ...$fields): SqlExpression
+    {
+        return SqlExpression::parenthesized(
+            new Expressions($field1, ...$fields)->join(', ')
+        );
+    }
+
+    public static function parenthesized(Expression $row, Expression ...$rows): SqlExpression
+    {
+        return SqlExpression::parenthesized(new self($row, ...$rows));
+    }
+
+    public function toSQL(): string
+    {
+        return 'VALUES '.$this->rows->join(', ')->toSQL();
+    }
+}

--- a/tests/Integration/Expression/ValuesTest.php
+++ b/tests/Integration/Expression/ValuesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\DbalTools\Integration\Expression;
+
+use Phpro\DbalTools\Expression\From;
+use Phpro\DbalTools\Expression\LiteralString;
+use Phpro\DbalTools\Expression\SqlExpression;
+use Phpro\DbalTools\Expression\Values;
+use Phpro\DbalTools\Test\DbalReaderTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ValuesTest extends DbalReaderTestCase
+{
+    protected static function schemaTables(): array
+    {
+        return [];
+    }
+
+    protected function createFixtures(): void
+    {
+
+    }
+
+    #[Test]
+    public function it_can_build_values(): void
+    {
+        $from = new From(
+            SqlExpression::tableReference(
+                Values::parenthesized(
+                    Values::row(new LiteralString('a1'), new LiteralString('b1')),
+                    Values::row(new LiteralString('a2'), new LiteralString('b2')),
+                    Values::row(new LiteralString('a3'), new LiteralString('b3')),
+                ),
+                'foo (a, b)'
+            )
+        );
+
+        $sql = <<<EOSQL
+            SELECT foo.a, foo.b
+            {$from->toSQL()}
+        EOSQL;
+
+        $result = self::connection()->executeQuery($sql);
+
+        self::assertSame(
+            [
+                ['a' => 'a1', 'b' => 'b1'],
+                ['a' => 'a2', 'b' => 'b2'],
+                ['a' => 'a3', 'b' => 'b3'],
+            ],
+            $result->fetchAllAssociative(),
+        );
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Provides a new Values expression:

```php
$from = new From(
    SqlExpression::tableReference(
        Values::parenthesized(
            Values::row(new LiteralString('a1'), new LiteralString('b1')),
            Values::row(new LiteralString('a2'), new LiteralString('b2')),
            Values::row(new LiteralString('a3'), new LiteralString('b3')),
        ),
        'foo (a, b)'
    )
);

$sql = <<<EOSQL
    SELECT foo.a, foo.b
    {$from->toSQL()}
EOSQL;
```
