### PR TITLE
feat(comparison): Add contains / containedBy methods to Comparison expression

### DIFF
--- a/src/Expression/Comparison.php
+++ b/src/Expression/Comparison.php
@@ -46,6 +46,16 @@ final readonly class Comparison implements Expression
         return new self($left, '<=', $right);
     }
 
+    public static function contains(Expression $left, Expression $right): self
+    {
+        return new self($left, '@>', $right);
+    }
+
+    public static function containedBy(Expression $left, Expression $right): self
+    {
+        return new self($left, '<@', $right);
+    }
+
     /**
      * @return non-empty-string
      */

--- a/tests/Integration/Expression/ComparisonTest.php
+++ b/tests/Integration/Expression/ComparisonTest.php
@@ -183,4 +183,100 @@ final class ComparisonTest extends DbalReaderTestCase
         self::assertSame($actualResults[1], true);
         self::assertSame($actualResults[2], false);
     }
+
+    #[Test]
+    public function it_can_perform_contains_checks_on_arrays(): void
+    {
+        $qb = $this->connection()->createQueryBuilder();
+        $qb->select(
+            Comparison::contains(
+                new SqlExpression('ARRAY[1,2,3]'),
+                new SqlExpression('ARRAY[1,2]')
+            )->toSQL(),
+            Comparison::contains(
+                new SqlExpression('ARRAY[1,2]'),
+                new SqlExpression('ARRAY[1,2,3]')
+            )->toSQL()
+        );
+
+        $actualResults = $qb->fetchNumeric();
+        if (!$actualResults) {
+            $this->fail('No results found');
+        }
+
+        self::assertSame($actualResults[0], true);
+        self::assertSame($actualResults[1], false);
+    }
+
+    #[Test]
+    public function it_can_perform_contains_checks_on_jsonb(): void
+    {
+        $qb = $this->connection()->createQueryBuilder();
+        $qb->select(
+            Comparison::contains(
+                new SqlExpression("'[\"ROLE_USER\", \"ROLE_ADMIN\"]'::jsonb"),
+                new SqlExpression("'[\"ROLE_USER\"]'::jsonb")
+            )->toSQL(),
+            Comparison::contains(
+                new SqlExpression("'[\"ROLE_USER\"]'::jsonb"),
+                new SqlExpression("'[\"ROLE_ADMIN\"]'::jsonb")
+            )->toSQL()
+        );
+
+        $actualResults = $qb->fetchNumeric();
+        if (!$actualResults) {
+            $this->fail('No results found');
+        }
+
+        self::assertSame($actualResults[0], true);
+        self::assertSame($actualResults[1], false);
+    }
+
+    #[Test]
+    public function it_can_perform_contained_by_checks_on_arrays(): void
+    {
+        $qb = $this->connection()->createQueryBuilder();
+        $qb->select(
+            Comparison::containedBy(
+                new SqlExpression('ARRAY[1,2]'),
+                new SqlExpression('ARRAY[1,2,3]')
+            )->toSQL(),
+            Comparison::containedBy(
+                new SqlExpression('ARRAY[1,2,3]'),
+                new SqlExpression('ARRAY[1,2]')
+            )->toSQL()
+        );
+
+        $actualResults = $qb->fetchNumeric();
+        if (!$actualResults) {
+            $this->fail('No results found');
+        }
+
+        self::assertSame($actualResults[0], true);
+        self::assertSame($actualResults[1], false);
+    }
+
+    #[Test]
+    public function it_can_perform_contained_by_checks_on_jsonb(): void
+    {
+        $qb = $this->connection()->createQueryBuilder();
+        $qb->select(
+            Comparison::containedBy(
+                new SqlExpression("'[\"ROLE_USER\"]'::jsonb"),
+                new SqlExpression("'[\"ROLE_USER\", \"ROLE_ADMIN\"]'::jsonb")
+            )->toSQL(),
+            Comparison::containedBy(
+                new SqlExpression("'[\"ROLE_ADMIN\"]'::jsonb"),
+                new SqlExpression("'[\"ROLE_USER\"]'::jsonb")
+            )->toSQL()
+        );
+
+        $actualResults = $qb->fetchNumeric();
+        if (!$actualResults) {
+            $this->fail('No results found');
+        }
+
+        self::assertSame($actualResults[0], true);
+        self::assertSame($actualResults[1], false);
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary


* Added a static `contains` method to `Comparison` that generates an expression using the `@>` operator for  containment checks.
* * Added a static `containedBy` method to `Comparison` that generates an expression using the `<@` operator for  containment checks.