### PR TITLE
Add HasNamedArguments attribute to validator constraints

### DIFF
--- a/src/Validator/SchemaFieldConstraint.php
+++ b/src/Validator/SchemaFieldConstraint.php
@@ -6,6 +6,7 @@ namespace Phpro\DbalTools\Validator;
 
 use Phpro\DbalTools\Column\TableColumnsInterface;
 use Phpro\DbalTools\Schema\Table;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 final class SchemaFieldConstraint extends Constraint
@@ -14,6 +15,7 @@ final class SchemaFieldConstraint extends Constraint
      * @param class-string<Table> $table
      * @param list<string>|null   $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         public string $table,
         public TableColumnsInterface $column,

--- a/src/Validator/TableKeyExistsConstraint.php
+++ b/src/Validator/TableKeyExistsConstraint.php
@@ -6,6 +6,7 @@ namespace Phpro\DbalTools\Validator;
 
 use Phpro\DbalTools\Column\TableColumnsInterface;
 use Phpro\DbalTools\Schema\Table;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 final class TableKeyExistsConstraint extends Constraint
@@ -14,6 +15,7 @@ final class TableKeyExistsConstraint extends Constraint
      * @param class-string<Table> $table
      * @param list<string>|null   $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         public string $table,
         public TableColumnsInterface $column,

--- a/src/Validator/UniqueConstraint.php
+++ b/src/Validator/UniqueConstraint.php
@@ -6,6 +6,7 @@ namespace Phpro\DbalTools\Validator;
 
 use Phpro\DbalTools\Column\TableColumnsInterface;
 use Phpro\DbalTools\Schema\Table;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 final class UniqueConstraint extends Constraint
@@ -18,6 +19,7 @@ final class UniqueConstraint extends Constraint
      * @param string|null                          $path            Path on which to display the error message. If not set, displayed at root object level.
      * @param list<string>|null                    $groups
      */
+    #[HasNamedArguments]
     public function __construct(
         public string $table,
         public array $columns,


### PR DESCRIPTION
## Summary
- Adds `#[HasNamedArguments]` to `SchemaFieldConstraint`, `TableKeyExistsConstraint`, and `UniqueConstraint`
- Symfony 7.4 requires this attribute on constraint constructors with typed parameters; without it the YAML loader passes the options array as a single positional argument, causing a TypeError


## References
- https://symfony.com/doc/current/validation/custom_constraint.html
- https://github.com/symfony/symfony/blob/7.4/CHANGELOG-7.4.md